### PR TITLE
Remove duplicated and malformed delete_rule function

### DIFF
--- a/rulepipe.py
+++ b/rulepipe.py
@@ -167,15 +167,6 @@ class RuleManager(object):
         return True
 
     def delete_rule(self, name):
-        if(self.ENV["USE_CACHE"]):
-            rule_name_hash = self.md5(name)
-            rule_time_hash = self.md5(name + "_cache_time")
-            self.redis.delete(rule_name_hash, rule_time_hash)
-        return self.db.delete_rule(name)
-
-        return is_added_to_database
-
-    def delete_rule(self, name):
         if self.ENV["USE_CACHE"]:
             rule_name_hash = self.md5(name)
             rule_time_hash = self.md5(name + "_cache_time")


### PR DESCRIPTION
In earlier merges, there should be some of conflicts and
delete_rule function  written twice in rulepipe.py.

One of them was including twice return statement.

This commit deletes twice return statement containing
delete_rule functions.